### PR TITLE
Fix `@purduehackers/time/react` exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,16 +192,3 @@ export default function MyComponent() {
   return <p>{lightningTimeClock}</p>
 }
 ```
-
-If you're using TypeScript, the `react` sub-package requires you to use `"moduleResolution": "Bundler"` in your tsconfig:
-
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    ...
-      "module": "ES2020",
-      "moduleResolution": "Bundler",
-  }
-}
-```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purduehackers/time",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "convert between traditional time and lightning time ⚡️",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
       "require": "./dist/index.js"
     },
     "./react": {
-      "types": "./dist/react/index.d.ts",
-      "import": "./dist/esm/react/index.js",
-      "require": "./dist/react/index.js"
+      "types": "./dist/react.d.ts",
+      "import": "./dist/esm/react.js",
+      "require": "./dist/react.js"
     }
   },
   "scripts": {

--- a/react/package.json
+++ b/react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@purduehackers/time/react",
+  "type": "module",
+  "main": "../dist/react.js",
+  "module": "../dist/esm/react.js",
+  "types": "../dist/react.d.ts",
+  "sideEffects": false
+}


### PR DESCRIPTION
TIL after publishing `v0.6.0` that TypeScript didn't support `exports` in `package.json` until very recently, and many projects wouldn't be able to use `@purduehackers/time/react` without upgrading TypeScript *and* changing `moduleResolution` to `nodenext` or `bundler` in their tsconfig.

I missed this during local testing because I tested it with `create-next-app`, which set `moduleResolution` to `bundler` by default. But it started breaking on some of my older projects, and in one of them when I set `moduleResolution` to `bundler`, it broke another package that had exported its types incorrectly & didn't work with `bundler` 🤦‍♂️

This PR attempts to make `@purduehackers/time/react` compatible with whatever `moduleResolution` your heart desires. Thank you to [this article](https://huakun.tech/docs/learnweb/language/typescript/#exports-for-typescript) for the help.

It works when testing locally so I'm going to merge, but I'm not sure if it'll break again on some of my older projects. If it's broken I'll fix it. The great thing about writing a PR that nobody will read for an npm package that nobody will use is that I can just break shit and cut a new release whenever I want!