### PR TITLE
`convertFromLightning()`: only return a Date object

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,7 @@ Examples:
 lt.convertFromLightning('8~0~0')
 
 /*
-returns {
-  withSeconds: '12:00:00 PM',
-  withoutSeconds: '12:00 PM'
-}
+returns a Date object with time 12:00:00 PM
 */
 ```
 
@@ -150,10 +147,7 @@ returns {
 lt.convertFromLightning('8~1~a|e')
 
 /*
-returns {
-  withSeconds: '12:09:26 PM',
-  withoutSeconds: '12:09 PM'
-}
+returns a Date object with time 12:09:26 PM
 */
 ```
 

--- a/src/time.ts
+++ b/src/time.ts
@@ -8,8 +8,7 @@ import {
   Colors,
   LightningString,
   LightningTimeParts,
-  StaticColors,
-  TraditionalTimeString
+  StaticColors
 } from './types'
 
 export const MILLIS_PER_CHARGE = 1318.359375 // 86400000 / 16^4
@@ -84,7 +83,7 @@ export class LightningTime {
     return stripCharges(lightningString)
   }
 
-  convertFromLightning(lightningString: string): TraditionalTimeString {
+  convertFromLightning(lightningString: string): Date {
     const isValid = validate(lightningString)
     if (!isValid) {
       throw new Error(
@@ -100,7 +99,7 @@ export class LightningTime {
     }
     const millis = (elapsed * 86400000) / (charges > 0 ? 65536 : 4096)
 
-    return msToTime(millis).date
+    return msToTime(millis)
   }
 
   getColors(lightningString: string): Colors {

--- a/src/time.ts
+++ b/src/time.ts
@@ -100,7 +100,7 @@ export class LightningTime {
     }
     const millis = (elapsed * 86400000) / (charges > 0 ? 65536 : 4096)
 
-    return msToTime(millis)
+    return msToTime(millis).date
   }
 
   getColors(lightningString: string): Colors {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -20,12 +20,6 @@ export interface LightningTimeParts {
   charges: string
 }
 
-export interface TraditionalTimeString {
-  withSeconds: string
-  withoutSeconds: string
-  date: Date
-}
-
 export interface Colors {
   boltColor: string
   zapColor: string

--- a/src/utils/ms-to-time.ts
+++ b/src/utils/ms-to-time.ts
@@ -10,6 +10,7 @@ const msToTime = (millis: number): Date => {
   date.setHours(hrs)
   date.setMinutes(mins)
   date.setSeconds(secs)
+  date.setMilliseconds(ms)
 
   return date
 }

--- a/src/utils/ms-to-time.ts
+++ b/src/utils/ms-to-time.ts
@@ -1,6 +1,4 @@
-import { TraditionalTimeString } from '../types'
-
-const msToTime = (millis: number): TraditionalTimeString => {
+const msToTime = (millis: number): Date => {
   const ms = millis % 1000
   millis = (millis - ms) / 1000
   const secs = millis % 60
@@ -13,14 +11,7 @@ const msToTime = (millis: number): TraditionalTimeString => {
   date.setMinutes(mins)
   date.setSeconds(secs)
 
-  return {
-    withSeconds: date.toLocaleTimeString(),
-    withoutSeconds: date.toLocaleTimeString([], {
-      hour: 'numeric',
-      minute: '2-digit'
-    }),
-    date
-  }
+  return date
 }
 
 export default msToTime

--- a/test/LightningTime.test.ts
+++ b/test/LightningTime.test.ts
@@ -70,17 +70,25 @@ describe('from lightning', () => {
   const lightningTime = new LightningTime()
   it('should convert from lightning', () => {
     const convert = lightningTime.convertFromLightning('8~0~0')
-    expect(convert).toMatchObject({
-      withSeconds: '12:00:00 PM',
-      withoutSeconds: '12:00 PM'
-    })
+
+    const expectedDate = new Date()
+    expectedDate.setHours(12)
+    expectedDate.setMinutes(0)
+    expectedDate.setSeconds(0)
+    expectedDate.setMilliseconds(0)
+
+    expect(convert.getTime()).toEqual(expectedDate.getTime())
   })
   it('should convert from lightning with charges', () => {
     const convert = lightningTime.convertFromLightning('8~0~0|a')
-    expect(convert).toMatchObject({
-      withSeconds: '12:00:13 PM',
-      withoutSeconds: '12:00 PM'
-    })
+    const expectedDate = new Date()
+
+    expectedDate.setHours(12)
+    expectedDate.setMinutes(0)
+    expectedDate.setSeconds(13)
+    expectedDate.setMilliseconds(183)
+
+    expect(convert.getTime()).toEqual(expectedDate.getTime())
   })
   it('should throw an error when time format is incorrect', () => {
     expect(() => lightningTime.convertFromLightning('8~0|')).toThrow(


### PR DESCRIPTION
I think this does what it should do. Would close #12.